### PR TITLE
solana: add redeemer to complete transfer ixs

### DIFF
--- a/solana/programs/swap-layer/src/error.rs
+++ b/solana/programs/swap-layer/src/error.rs
@@ -32,6 +32,7 @@ pub enum SwapLayerError {
     UnsupportedFillType = 0x115,
     SwapTimeLimitNotExceeded = 0x116,
     ImmutableProgram = 0x118,
+    InvalidRedeemer = 0x11a,
 
     // EVM Execution Param errors
     InvalidBaseFee = 0x200,

--- a/solana/programs/swap-layer/src/processor/complete/transfer/payload.rs
+++ b/solana/programs/swap-layer/src/processor/complete/transfer/payload.rs
@@ -12,17 +12,25 @@ pub struct CompleteTransferPayload<'info> {
     #[account(mut)]
     payer: Signer<'info>,
 
+    /// This redeemer is used to check against the recipient. If the redeemer is the same as the
+    /// recipient, he is free to redeem his tokens directly as USDC even if swap instructions are
+    /// encoded.
+    redeemer: Signer<'info>,
+
     #[account(
         constraint = {
             let swap_msg = consume_swap_layer_fill.read_message_unchecked();
 
-            require!(
-                matches!(
-                    swap_msg.output_token,
-                    OutputToken::Usdc
-                ),
-                SwapLayerError::InvalidOutputToken
-            );
+            match &swap_msg.output_token {
+                OutputToken::Usdc => {}
+                OutputToken::Gas(_) | OutputToken::Other { .. } => {
+                    require_eq!(
+                        redeemer.key(),
+                        Pubkey::from(swap_msg.recipient),
+                        SwapLayerError::InvalidRedeemer
+                    );
+                }
+            }
 
             true
         }


### PR DESCRIPTION
The additional signer (redeemer) is used to check against the encoded recipient. If he is the recipient, he has special access to redeem USDC instead of having to use encoded swap parameters for `OutputToken::Gas` or `OutputToken::Other`.