### PR TITLE
solana: some clean up

### DIFF
--- a/solana/programs/swap-layer/src/processor/initiate/transfer.rs
+++ b/solana/programs/swap-layer/src/processor/initiate/transfer.rs
@@ -167,7 +167,7 @@ pub fn initiate_transfer(ctx: Context<InitiateTransfer>) -> Result<()> {
         ctx.accounts.token_program.to_account_info(),
         token::CloseAccount {
             account: custody_token.to_account_info(),
-            destination: ctx.accounts.payer.to_account_info(),
+            destination: ctx.accounts.prepared_by.to_account_info(),
             authority: ctx.accounts.custodian.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],

--- a/solana/programs/swap-layer/src/processor/stage_outbound.rs
+++ b/solana/programs/swap-layer/src/processor/stage_outbound.rs
@@ -1,7 +1,7 @@
 use crate::{
     composite::*,
     error::SwapLayerError,
-    state::{Peer, RedeemOption, StagedOutbound, StagedOutboundInfo, StagedRedeem},
+    state::{RedeemOption, StagedOutbound, StagedOutboundInfo, StagedRedeem},
     utils, TRANSFER_AUTHORITY_SEED_PREFIX,
 };
 use anchor_lang::{prelude::*, system_program};
@@ -327,17 +327,11 @@ pub fn stage_outbound(ctx: Context<StageOutbound>, args: StageOutboundArgs) -> R
                     transfer_amount,
                 )?;
 
-                let peer_seeds = &ctx.accounts.target_peer.seeds;
-                token_interface::sync_native(CpiContext::new_with_signer(
+                token_interface::sync_native(CpiContext::new(
                     src_token_program.to_account_info(),
                     token_interface::SyncNative {
                         account: custody_token.to_account_info(),
                     },
-                    &[&[
-                        Peer::SEED_PREFIX,
-                        &peer_seeds.chain.to_be_bytes(),
-                        &[peer_seeds.bump],
-                    ]],
                 ))?;
 
                 sender.key()

--- a/solana/programs/swap-layer/src/state/staged/outbound.rs
+++ b/solana/programs/swap-layer/src/state/staged/outbound.rs
@@ -67,7 +67,6 @@ impl StagedOutbound {
     const BASE_SIZE: usize = 8 // DISCRIMINATOR
         + StagedOutboundInfo::INIT_SPACE
         + 1 // StagedRedeem discrimant
-        + 1 // encoded_output_token === None
         ;
 
     pub fn try_compute_size(


### PR DESCRIPTION
- Remove unnecessary signer seeds for sync native CPI call
- Fix space calculation for `StagedOutbound`
- Fix beneficiary of closed custody token account from payer to the one who paid to prepared the outbound transfer